### PR TITLE
Docker Compose changes and Create Dir so touch in deployment.sh does not fail

### DIFF
--- a/deployment.sh
+++ b/deployment.sh
@@ -79,9 +79,11 @@ fi
 
 echo "Starting services..."
 
-mkdir ./db_sqlite3
 
-touch ./db_sqlite3/db.sqlite3
+if [ ! -f "./db.sqlite3" ]; then
+    touch ./db.sqlite3
+fi
+
 
 sudo APP_DOMAIN="${APP_DOMAIN}:${SERVER_PORT}" CLIENT_PORT=${CLIENT_PORT} SERVER_PORT=${SERVER_PORT} WSGI_PORT=${WSGI_PORT} DB_URL=${DATABASE_URL}  $DOCKER_COMPOSE_CMD up -d
 

--- a/deployment.sh
+++ b/deployment.sh
@@ -79,6 +79,8 @@ fi
 
 echo "Starting services..."
 
+mkdir ./db_sqlite3
+
 touch ./db_sqlite3/db.sqlite3
 
 sudo APP_DOMAIN="${APP_DOMAIN}:${SERVER_PORT}" CLIENT_PORT=${CLIENT_PORT} SERVER_PORT=${SERVER_PORT} WSGI_PORT=${WSGI_PORT} DB_URL=${DATABASE_URL}  $DOCKER_COMPOSE_CMD up -d

--- a/deployment.sh
+++ b/deployment.sh
@@ -56,14 +56,18 @@ else
 
     sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 fi
+
 if [[ $(which docker-compose) ]]; then
-    echo "Docker Compose is already installed"
+    echo "Docker Compose is already installed as 'docker-compose'"
+    DOCKER_COMPOSE_CMD="docker-compose"
+elif [[ $(which docker) && $(docker compose version) ]]; then
+    echo "Docker Compose is available as 'docker compose'"
+    DOCKER_COMPOSE_CMD="docker compose"
 else
     echo "Docker Compose is not installed, installing now..."
-
     sudo curl -L "https://github.com/docker/compose/releases/download/v2.16.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-
     sudo chmod +x /usr/local/bin/docker-compose
+    DOCKER_COMPOSE_CMD="docker-compose"
 fi
 
 echo "Downloading configuration files..."
@@ -77,6 +81,7 @@ echo "Starting services..."
 
 touch ./db_sqlite3/db.sqlite3
 
-sudo APP_DOMAIN="${APP_DOMAIN}:${SERVER_PORT}" CLIENT_PORT=${CLIENT_PORT} SERVER_PORT=${SERVER_PORT} WSGI_PORT=${WSGI_PORT} DB_URL=${DATABASE_URL}  docker-compose up -d
+sudo APP_DOMAIN="${APP_DOMAIN}:${SERVER_PORT}" CLIENT_PORT=${CLIENT_PORT} SERVER_PORT=${SERVER_PORT} WSGI_PORT=${WSGI_PORT} DB_URL=${DATABASE_URL}  $DOCKER_COMPOSE_CMD up -d
 
 echo "Done"
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
 #      - EMAIL_USE_TLS=True
 #      - EMAIL_FROM=no-reply@example.com  #Default sender email address
     volumes:
-      - db_sqlite3:/app/db.sqlite3
+      - ./db_sqlite3:/app/db.sqlite3
     ports:
       - '${WSGI_PORT:-8000}:8000'
     networks:


### PR DESCRIPTION
#### EDIT: pushing directly to source, sorry. I didn't realize this repo wasn't original. see https://github.com/WongSaang/chatgpt-ui/pull/235

----


Hello,

Currently, there are two minor issues with the deployments file:

1.  The touch command will fail as touch does not create directories. a `mkdir `beforehand is necessary. **However**, the docker-compose.yml file simply specifies the database as 

```
volumes:
      - db_sqlite3:/app/db.sqlite3
```
which would not create the necessary dbfile in the current directory, but a named volume instead - which doesn't work for this instance as compose will just throw an error. Thus I have changed this to `./db_sqlite3`. Additionally, if creating a specific directory is desired, I can modify that as well.

2. the check for if compose is installed only takes into account if it is installed as `docker-compose`. a separate, `docker compose` exists and used by many (myself included). This modification checks for both, and uses the appropriate installation method to do the `up -d `.

Might fix [#146](https://github.com/WongSaang/chatgpt-ui/issues/146)

